### PR TITLE
minor ux update

### DIFF
--- a/Source/BindableFunctions.cs
+++ b/Source/BindableFunctions.cs
@@ -238,12 +238,12 @@ namespace DebugMod
 
         #region SaveStates 
 
-        [BindableMethod(name = "Position Save", category = "SaveStates")]
+        [BindableMethod(name = "Position Save", category = "Savestates")]
         public static void SavePosition()
         {
             SavePositionManager.SavePosition();
         }
-        [BindableMethod(name = "Position Load", category = "SaveStates")]
+        [BindableMethod(name = "Position Load", category = "Savestates")]
         public static void LoadPosition()
         {
             SavePositionManager.LoadPosition();

--- a/Source/BindableFunctions.cs
+++ b/Source/BindableFunctions.cs
@@ -335,6 +335,43 @@ namespace DebugMod
             HeroController.instance.vignette.enabled = !HeroController.instance.vignette.enabled;
         }
 
+        [BindableMethod(name = "Deactivate Visual Masks", category = "Visual")]
+        public static void DeactivateVisualMasks() {
+            int ctr = 0;
+
+            void disableMask(GameObject go) {
+                foreach (Renderer r in go.GetComponentsInChildren<Renderer>()) {
+                    if (r.enabled) {
+                        ctr++;
+                        r.enabled = false;
+                    }
+                }
+            }
+
+            float knightZ = HeroController.instance.transform.position.z;
+            foreach (GameObject go in GameObject.FindObjectsOfType<GameObject>()) {
+                if (go.transform.position.z > knightZ) continue;
+
+                // A collection of ways to identify masks. It's possible some slip through the cracks I guess
+                if (go.name.StartsWith("msk_"))
+                    disableMask(go);
+                else if (go.name.StartsWith("Tut_msk"))
+                    disableMask(go);
+                else if (go.name.StartsWith("black_solid"))
+                    disableMask(go);
+                else if (go.name.ToLower().Contains("vignette"))
+                    disableMask(go);
+                else if (go.LocateMyFSM("unmasker") is PlayMakerFSM)
+                    disableMask(go);
+                else if (go.LocateMyFSM("remasker_inverse") is PlayMakerFSM)
+                    disableMask(go);
+                else if (go.LocateMyFSM("remasker") is PlayMakerFSM)
+                    disableMask(go);
+            }
+
+            Console.AddLine($"Deactivated {ctr} masks");
+        }
+
         [BindableMethod(name = "Toggle Hero Light", category = "Visual")]
         public static void ToggleHeroLight()
         {

--- a/Source/DebugMod.cs
+++ b/Source/DebugMod.cs
@@ -171,7 +171,11 @@ namespace DebugMod
         
         public override string GetVersion()
         {
-            return "1.4.6-early";
+            string version = "1.5.0";
+#if DEBUG
+            version = string.Concat(version, "-dev");
+#endif
+            return version;
         }
 
         public override bool IsCurrent()
@@ -186,7 +190,7 @@ namespace DebugMod
             catch (Exception)
             {
                 return true;
-            }
+      u      }
             */
             return true;
         }

--- a/Source/SavePositionManager.cs
+++ b/Source/SavePositionManager.cs
@@ -18,7 +18,9 @@ namespace DebugMod
         public static Vector3 KnightPos;
         public static Vector3 CamPos;
         public static Vector2 KnightVel;
-       // public static List
+        public static string PositionScene;
+        public static bool InitialisedPosition = false;
+        // public static List
         public static void SavePosition()
         {
 
@@ -26,42 +28,47 @@ namespace DebugMod
             KnightPos = DebugMod.RefKnight.gameObject.transform.position;
             KnightVel = HeroController.instance.current_velocity;
             CamPos = DebugMod.RefCamera.gameObject.transform.position;
+            PositionScene = DebugMod.GetSceneName();
+            InitialisedPosition = true;
 
-
-            
             //schmove = DebugMod.RefKnight.
             // save fsms :eyes:
-            
+
             FSMs = GetAllEnemies(FSMs2);
             FSMs.ForEach(delegate (EnemyData dat)
             {
                 dat.gameObject.SetActive(false);
             });
 
+            Console.AddLine("Positional save set in " + DebugMod.GetSceneName());
+
         }
         public static void LoadPosition()
         {
-            try
-            {
-                RemoveAll();
-                FSMs2 = Create();
-                // Move knight to saved location, change velocity to saved velocity, Move Camera to saved campos, 
-                //ReflectionHelper.SetField<HeroController, float>(HeroController.instance, "dash_timer", newValue);
-                DebugMod.RefKnight.gameObject.transform.position = KnightPos;
-                HeroController.instance.current_velocity = KnightVel;
-                DebugMod.RefCamera.gameObject.transform.position = CamPos;
-            }
-            catch(Exception     e)
-            {
-                Console.AddLine(e.Message);
-                Console.AddLine(e.StackTrace);
-            }
-            //HeroController.instance.DASH_COOLDOWN =
-            //HeroController.instance.DASH_COOLDOWN_CH =
-            //HeroController.instance.dash
-            
-            //DebugMod.RefCamera.SnapTo(DebugMod.RefKnight.transform.position.x, DebugMod.RefKnight.transform.position.y);
+            if (PositionScene == DebugMod.GetSceneName() && InitialisedPosition) { 
+                try
+                {
+                    RemoveAll();
+                    FSMs2 = Create();
+                    // Move knight to saved location, change velocity to saved velocity, Move Camera to saved campos, 
+                    //ReflectionHelper.SetField<HeroController, float>(HeroController.instance, "dash_timer", newValue);
+                    DebugMod.RefKnight.gameObject.transform.position = KnightPos;
+                    HeroController.instance.current_velocity = KnightVel;
+                    DebugMod.RefCamera.gameObject.transform.position = CamPos;
+                }
+                catch(Exception     e)
+                {
+                    Console.AddLine(e.Message);
+                    Console.AddLine(e.StackTrace);
+                }
+                //HeroController.instance.DASH_COOLDOWN =
+                //HeroController.instance.DASH_COOLDOWN_CH =
+                //HeroController.instance.dash
 
+                //DebugMod.RefCamera.SnapTo(DebugMod.RefKnight.transform.position.x, DebugMod.RefKnight.transform.position.y);
+            } else {
+                Console.AddLine("No positional save in " + DebugMod.GetSceneName());
+            }
         }
 
         public static List<EnemyData> Create() 


### PR DESCRIPTION
- added flib's demasker function (useful if you have dreamer softlock whitescreen, or the bugged birthplace climb "filter", and similar)
- did some UX additions to make sure you dont call the savepositions without setting one first or being in the same scene.

is there a reason why you're using `public static` variables in SavePositionManager, btw? it seems to me like the kind of scenario where you'd want to use `private` vars instead, unless i missed something of course.

is it on purpose to deactivate all enemies when setting the position? I can see it being useful, just wasn't expecting it :') might be good as a toggleable option, just because of how enemies are relevant to movement often. also this is looking like *actual* savestates rather than just the "(re)load scene at position" the other one is. I like the potential here 👀 